### PR TITLE
fix: avoid rounding up milliseconds to next minute

### DIFF
--- a/src/helpers/msToMMSS.ts
+++ b/src/helpers/msToMMSS.ts
@@ -1,8 +1,11 @@
 const pad = (n: number) => (n <= 9 ? `0${n}` : `${n}`);
 
 export function msToMMSS(ms: number) {
-  const seconds = Math.round(ms / 1000);
-  const m = Math.trunc(seconds / 60);
-  const s = seconds - m * 60;
+  // Convert milliseconds to seconds and avoid rounding up so that
+  // 59.9s is represented as 00:59 instead of 01:00. Using Math.floor
+  // ensures the time never exceeds the actual duration.
+  const seconds = Math.floor(ms / 1000);
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
   return `${pad(m)}:${pad(s)}`;
 }


### PR DESCRIPTION
## Summary
- prevent `msToMMSS` from rounding milliseconds up to the next minute

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a08ee0a75083259f98960ba8546589